### PR TITLE
Derive a type class only for wrapper types (unary product types)

### DIFF
--- a/src/core/interface.scala
+++ b/src/core/interface.scala
@@ -297,34 +297,6 @@ abstract class ReadOnlyCaseClass[Typeclass[_], Type](
   final def typeAnnotations: Seq[Any] = typeAnnotationsArray
 }
 
-abstract class UnaryReadOnlyCaseClass[Typeclass[_], Type](
-  val typeName: TypeName,
-  val isObject: Boolean,
-  val isValueClass: Boolean,
-  /** a [[ReadOnlyParam]] representing the parameter in the case class */
-  parametersArray: Array[ReadOnlyParam[Typeclass, Type]],
-  annotationsArray: Array[Any],
-  typeAnnotationsArray: Array[Any]
-) extends Serializable {
-
-
-  /** A [[ReadOnlyParam]] object representing the parameter in the case class */
-  def parameter: ReadOnlyParam[Typeclass, Type] = parametersArray.head
-
-  override def toString: String = s"UnaryReadOnlyCaseClass(${typeName.full}, $parameter)"
-
-  /** a sequence of objects representing all of the annotations on the case class
-    *
-    *  For efficiency, this sequence is implemented by an `Array`, but upcast to a
-    *  [[scala.collection.Seq]] to hide the mutable collection API. */
-  final def annotations: Seq[Any] = annotationsArray
-
-  /** a sequence of objects representing all of the type annotations on the case class
-    *
-    *  For efficiency, this sequence is implemented by an `Array`, but upcast to a
-    *  [[scala.collection.Seq]] to hide the mutable collection API. */
-  final def typeAnnotations: Seq[Any] = typeAnnotationsArray
-}
 
 /** [[CaseClass]] contains all information that exists in a [[ReadOnlyCaseClass]], as well as methods and context
  *  required for construct an instance of this case class/object (e.g. default values for constructor parameters)
@@ -394,70 +366,6 @@ abstract class CaseClass[Typeclass[_], Type] (
   def rawConstruct(fieldValues: Seq[Any]): Type
 }
 
-/** [[CaseClass]] contains all information that exists in a [[ReadOnlyCaseClass]], as well as methods and context
-  *  required for construct an instance of this case class/object (e.g. default values for constructor parameters)
-  *
-  *  @param typeName         the name of the case class
-  *  @param isObject         true only if this represents a case object rather than a case class
-  *  @param parameter        the [[Param]] value for this case class
-  *  @param annotationsArray  an array of instantiated annotations applied to this case class
-  *  @param typeAnnotationsArray  an array of instantiated type annotations applied to this case class
-  *  @tparam Typeclass  type constructor for the typeclass being derived
-  *  @tparam Type       generic type of this parameter */
-abstract class UnaryCaseClass[Typeclass[_], Type] (
-  override val typeName: TypeName,
-  override val isObject: Boolean,
-  override val isValueClass: Boolean,
-  parametersArray: Array[Param[Typeclass, Type]],
-  annotationsArray: Array[Any],
-  typeAnnotationsArray: Array[Any]
-) extends UnaryReadOnlyCaseClass[Typeclass, Type](
-  typeName,
-  isObject,
-  isValueClass,
-  // Safe to cast as we're never mutating the array
-  parametersArray.asInstanceOf[Array[ReadOnlyParam[Typeclass, Type]]],
-  annotationsArray,
-  typeAnnotationsArray
-) {
-
-  /** A [[Param]] object representing the parameter in the case class */
-  override def parameter: Param[Typeclass, Type] = parametersArray.head
-
-  override def toString: String = s"UnaryCaseClass(${typeName.full}, $parameter)"
-  /** constructs a new instance of the case class type
-    *
-    *  This method will be implemented by the Magnolia macro to make it possible to construct
-    *  instances of case classes generically in user code, that is, without knowing their type
-    *  concretely.
-    *
-    *  To construct a new case class instance, the method takes a lambda which defines how each
-    *  parameter in the new case class should be constructed. See the [[Param]] class for more
-    *  information on constructing parameter values from a [[Param]] instance.
-    *
-    *  @param makeParam  lambda for converting a generic [[Param]] into the value to be used for
-    *                    this parameter in the construction of a new instance of the case class
-    *  @return  a new instance of the case class */
-  def construct[Return](makeParam: Param[Typeclass, Type] => Return): Type
-
-  def constructMonadic[Monad[_], PType](makeParam: Param[Typeclass, Type] => Monad[PType])(implicit monadic: Monadic[Monad]): Monad[Type]
-
-  def constructEither[Err, PType](makeParam: Param[Typeclass, Type] => Either[Err, PType]): Either[List[Err], Type]
-
-  /** constructs a new instance of the case class type
-    *
-    *  Like [[construct]] this method is implemented by Magnolia and lets you construct case class
-    *  instances generically in user code, without knowing their type concretely.
-    *
-    *  `rawConstruct`, however, is more low-level in that it expects you to provide a [[Seq]]
-    *  containing all the field values for the case class type, in order and with the correct types.
-    *
-    * @param fieldValues contains the field values for the case class instance to be constructed,
-    *                    in order and with the correct types.
-    *  @return  a new instance of the case class
-    *  @throws  IllegalArgumentException if the size of `paramValues` differs from the size of [[parameters]] */
-  def rawConstruct(fieldValues: Seq[Any]): Type
-}
 /** represents a sealed trait and the context required to construct a new typeclass instance
   *  corresponding to it
   *
@@ -532,6 +440,25 @@ final case class TypeName(owner: String, short: String, typeArguments: Seq[TypeN
   *                     whose full name contains the given [[String]]
   */
 final class debug(typeNamePart: String = "") extends scala.annotation.StaticAnnotation
+
+object typeValidation {
+  /**
+    * This annotation can be attached to the `combine` method of a type class companion.
+    * If specified, it will check that we only derive type classes for types with more than `n` members
+    *
+    * @param n inclusive, exactly `n` members is fine
+    */
+  final class minMembers(n: Int) extends scala.annotation.StaticAnnotation
+
+  /**
+    * This annotation can be attached to the `combine` method of a type class companion.
+    * If specified, it will check that we only derive type classes for types with less than `n` members
+    *
+    * @param n inclusive, exactly `n` members is fine
+    */
+  final class maxMembers(n: Int) extends scala.annotation.StaticAnnotation
+
+}
 
 private[magnolia] final case class EarlyExit[E](e: E) extends Exception with util.control.NoStackTrace
 

--- a/src/examples/wrappers.scala
+++ b/src/examples/wrappers.scala
@@ -28,8 +28,13 @@ object ToString {
 
   type Typeclass[A] = ToString[A]
 
-  def combine[A](ctx: UnaryReadOnlyCaseClass[ToString, A]): ToString[A] =
-    (a: A) => ctx.parameter.typeclass.str(ctx.parameter.dereference(a))
+  @typeValidation.minMembers(1)
+  @typeValidation.maxMembers(1)
+  def combine[A](ctx: ReadOnlyCaseClass[ToString, A]): ToString[A] =
+    (a: A) => {
+      val param = ctx.parameters.head
+      param.typeclass.str(param.dereference(a))
+    }
 
   implicit def derive[A]: ToString[A] = macro Magnolia.gen[A]
 
@@ -47,7 +52,9 @@ object FromString {
 
   type Typeclass[A] = FromString[A]
 
-  def combine[A](ctx: UnaryCaseClass[FromString, A]): FromString[A] =
+  @typeValidation.minMembers(1)
+  @typeValidation.maxMembers(1)
+  def combine[A](ctx: CaseClass[FromString, A]): FromString[A] =
     (str: String) => ctx.construct(p => p.typeclass.fromStr(str))
 
   implicit def derive[A]: FromString[A] = macro Magnolia.gen[A]

--- a/src/examples/wrappers.scala
+++ b/src/examples/wrappers.scala
@@ -1,0 +1,58 @@
+/*
+
+    Magnolia, version 0.17.0. Copyright 2018-20 Jon Pretty, Propensive OÜ.
+
+    The primary distribution site is: https://propensive.com/
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+    compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is
+    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and limitations under the License.
+
+*/
+package magnolia.examples
+import magnolia._
+import scala.language.experimental.macros
+
+/* automatically derived only for wrapper types (unary product types) */
+trait ToString[A] {
+  def str(a: A): String
+}
+
+object ToString {
+  def apply[A: ToString]: ToString[A] = implicitly
+
+  type Typeclass[A] = ToString[A]
+
+  def combine[A](ctx: UnaryReadOnlyCaseClass[ToString, A]): ToString[A] =
+    (a: A) => ctx.parameter.typeclass.str(ctx.parameter.dereference(a))
+
+  implicit def derive[A]: ToString[A] = macro Magnolia.gen[A]
+
+  implicit val str: ToString[String] = (a: String) => a
+  implicit val int: ToString[Int] = (a: Int) => a.toString
+}
+
+
+trait FromString[A] {
+  def fromStr(str: String): A
+}
+
+object FromString {
+  def apply[A: FromString]: FromString[A] = implicitly
+
+  type Typeclass[A] = FromString[A]
+
+  def combine[A](ctx: UnaryCaseClass[FromString, A]): FromString[A] =
+    (str: String) => ctx.construct(p => p.typeclass.fromStr(str))
+
+  implicit def derive[A]: FromString[A] = macro Magnolia.gen[A]
+
+  implicit val str: FromString[String] = (a: String) => a
+  implicit val int: FromString[Int] = (a: String) => a.toInt
+
+}

--- a/src/test/tests.scala
+++ b/src/test/tests.scala
@@ -739,6 +739,7 @@ object Tests extends Suite("Magnolia tests") {
     }
 
     test("support dispatch without combine") {
+      NoCombine.gen[Halfy]
       implicitly[NoCombine[Halfy]].nameOf(Righty())
     }.assert(_ == "Righty")
 
@@ -760,11 +761,11 @@ object Tests extends Suite("Magnolia tests") {
 
     test("readonly unary product types: not support case object unary product type") {
       scalac"ToString.derive[A.type]"
-      }.assert(_ == TypecheckError(txt"magnolia: You can only derive instances for ToString.Typeclass for (case) classes with one member"))
+      }.assert(_ == TypecheckError(txt"magnolia: magnolia.tests.A.type is not a valid type for ToString.Typeclass because at least 1 members are required (it has 0)"))
 
     test("readonly unary product types: not support case class with two members") {
       scalac"ToString.derive[StringWrapperComposite.type]"
-      }.assert(_ == TypecheckError(txt"magnolia: You can only derive instances for ToString.Typeclass for (case) classes with one member"))
+    }.assert(_ == TypecheckError(txt"magnolia: magnolia.tests.StringWrapperComposite.type is not a valid type for ToString.Typeclass because at least 1 members are required (it has 0)"))
 
     test("unary product types: support wrapper case class") {
       FromString[StringWrapper].fromStr("a")
@@ -784,10 +785,10 @@ object Tests extends Suite("Magnolia tests") {
 
     test("unary product types: not support case object unary product type") {
       scalac"FromString.derive[A.type]"
-    }.assert(_ == TypecheckError(txt"magnolia: You can only derive instances for FromString.Typeclass for (case) classes with one member"))
+    }.assert(_ == TypecheckError(txt"magnolia: magnolia.tests.A.type is not a valid type for FromString.Typeclass because at least 1 members are required (it has 0)"))
 
     test("unary product types: not support case class with two members") {
-      scalac"FromString.derive[StringWrapperComposite.type]"
-    }.assert(_ == TypecheckError(txt"magnolia: You can only derive instances for FromString.Typeclass for (case) classes with one member"))
+      scalac"FromString.derive[StringWrapperComposite]"
+    }.assert(_ == TypecheckError(txt"magnolia: magnolia.tests.StringWrapperComposite is not a valid type for FromString.Typeclass because at no more than 1 members are required (it has 2)"))
   }
 }


### PR DESCRIPTION
Hi again @propensive 

We need to reintroduce this functionality into doobie after https://github.com/tpolecat/doobie/pull/1343 .

So this is a first stab at it. If we continue down this path we'll pretty quickly see an explosion of needed types, so it's not necessarily a good path. The whole thing is really a whole lot of ceremony around some critically placed `if`s.

I thought about introducing some kind of type-level set of requirements (for instance "must be case class", "must have more/less than N members", and so on) which the macro could query. This, however, was the easiest way forward.

Looking forward to hearing what you think