### PR TITLE
Add possibility to separate `gen` from `combine`

### DIFF
--- a/src/core/interface.scala
+++ b/src/core/interface.scala
@@ -440,6 +440,13 @@ final case class TypeName(owner: String, short: String, typeArguments: Seq[TypeN
   */
 final class debug(typeNamePart: String = "") extends scala.annotation.StaticAnnotation
 
+/**
+  * Allows `combine`, `dispatch` and `fallback` to be implemented in another object.
+  * This makes it possible to export more than one derivation in an object
+  * @param companion the object where the methods are defined
+  */
+final class proxy(companion: Any) extends scala.annotation.StaticAnnotation
+
 private[magnolia] final case class EarlyExit[E](e: E) extends Exception with util.control.NoStackTrace
 
 object MagnoliaUtil {

--- a/src/examples/proxies.scala
+++ b/src/examples/proxies.scala
@@ -1,0 +1,86 @@
+/*
+
+    Magnolia, version 0.17.0. Copyright 2018-20 Jon Pretty, Propensive OÜ.
+
+    The primary distribution site is: https://propensive.com/
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+    compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is
+    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and limitations under the License.
+
+*/
+package magnolia.examples
+
+import magnolia._
+import scala.language.experimental.macros
+
+/** Demonstrate some flexibility for the user-facing API of your type classes
+  *
+  * - how to export multiple type class derivations behind one underscore import
+  * - how to offer both auto and semiauto derivations through different imports
+  */
+object proxies {
+  // if wanted these can go in a trait and be reexported through other paths as well
+  object auto extends auto
+
+  trait auto {
+    @proxy(ToString1)
+    implicit def deriveToString1[A]: ToString1[A] = macro Magnolia.gen[A]
+
+    @proxy(ToString2)
+    implicit def deriveToString2[A]: ToString2[A] = macro Magnolia.gen[A]
+  }
+
+  // or directly in an object, or in the companion objects or wherever
+  object semiauto {
+    @proxy(ToString1)
+    def deriveToString1[A]: ToString1[A] = macro Magnolia.gen[A]
+
+    @proxy(ToString2)
+    def deriveToString2[A]: ToString2[A] = macro Magnolia.gen[A]
+  }
+
+  implicit class Syntax[T](private val t: T) extends AnyVal {
+    def str1(implicit ev: ToString1[T]): String = ev.str1(t)
+    def str2(implicit ev: ToString2[T]): String = ev.str2(t)
+  }
+
+  // an example type class which just stringifies data in a non-useful way
+  trait ToString1[A] {
+    def str1(a: A): String
+  }
+
+  object ToString1 {
+    def apply[A: ToString1]: ToString1[A] = implicitly
+
+    type Typeclass[A] = ToString1[A]
+
+    def combine[A](ctx: ReadOnlyCaseClass[ToString1, A]): ToString1[A] =
+      (a: A) => ctx.parameters.map(param => param.typeclass.str1(param.dereference(a))).mkString(", ")
+
+    implicit val str: ToString1[String] = (a: String) => a
+    implicit val int: ToString1[Int] = (a: Int) => a.toString
+  }
+
+  // this is just here to test that we can export more than one derivation
+  trait ToString2[A] {
+    def str2(a: A): String
+  }
+
+  object ToString2 {
+    def apply[A: ToString2]: ToString2[A] = implicitly
+
+    type Typeclass[A] = ToString2[A]
+
+    def combine[A](ctx: ReadOnlyCaseClass[ToString2, A]): ToString2[A] =
+      (a: A) => ctx.parameters.map(param => param.typeclass.str2(param.dereference(a))).mkString("; ")
+
+    implicit val str: ToString2[String] = (a: String) => a
+    implicit val int: ToString2[Int] = (a: Int) => a.toString
+  }
+}

--- a/src/test/tests.scala
+++ b/src/test/tests.scala
@@ -734,5 +734,41 @@ object Tests extends Suite("Magnolia tests") {
     test("support dispatch without combine") {
       implicitly[NoCombine[Halfy]].nameOf(Righty())
     }.assert(_ == "Righty")
+
+    test("proxies: semiauto ToString1") {
+      import proxies._, semiauto._
+      implicit val x: ToString1[Param] = deriveToString1[Param]
+      Param("a", "b").str1
+    }.assert(_ == "a, b")
+
+    test("proxies: semiauto ToString1 is not auto") {
+      import proxies._, semiauto._
+      scalac"""Param("a", "b").str1"""
+    }.assert(_ == TypecheckError(txt"could not find implicit value for parameter ev: magnolia.examples.proxies.ToString1[magnolia.tests.Param]"))
+
+    test("proxies: semiauto ToString1 (nested)") {
+      import proxies._, semiauto._
+      implicit val x: ToString1[Param] = deriveToString1[Param]
+      implicit val y: ToString1[Test] = deriveToString1[Test]
+      Test(Param("a", "b")).str1
+    }.assert(_ == "a, b")
+
+    test("proxies: semiauto ToString1 is not auto (nested)") {
+      import proxies._, semiauto._
+      // skip `deriveToString1[Param]`
+      scalac"deriveToString1[Test]"
+    }.assert(_ == TypecheckError(txt"""magnolia: could not find ToString1.Typeclass for type magnolia.tests.Param
+    in parameter 'param' of product type magnolia.tests.Test
+"""))
+
+    test("proxies: auto ToString1 (nested)") {
+      import proxies._, auto._
+      Test(Param("a", "b")).str1
+    }.assert(_ == "a, b")
+
+    test("proxies: auto ToString2 (nested)") {
+      import proxies._, auto._
+      Test(Param("a", "b")).str2
+    }.assert(_ == "a; b")
   }
 }


### PR DESCRIPTION
This solves two related issues with magnolia:

### auto/semiauto

Some people prefer automatic derivation, while others prefer semiauto. As it stands now the type class author has to decide which one to offer (based on the existence of `implicit` of the `gen` method which is implemented by the magnolia macro)

This choice should be made by users instead. The mechanism introduced in this PR enables a type class author to offer both

### Bundling more than one type class derivation behind one import

As it stands now, it's not really possible to offer more than one type class derivation through a wildcard import, because they ultimately need to be implemented in an `object`, where the `combine` methods and so on would clash.

## Workarounds 

If you look around you'll find that many projects have workarounds by writing their own macros around the magnolia macro. For instance:
- https://github.com/spotify/magnolify/blob/master/cats/src/main/scala/magnolify/cats/auto/CatsMacros.scala#L30
- https://github.com/softwaremill/tapir/blob/master/core/src/main/scala/sttp/tapir/generic/auto/package.scala#L9

## Proposed solution

Add an annotation to `gen` where we can specify the `object` which has the `combine` method and the rest of the machinery.
For now this annotation is called `@proxy`, but I'm sure there are better names. 

Example, given two non-interesting type classes called `ToString1` and `ToString2`:

```scala

  object auto {
    @proxy(ToString1)
    implicit def deriveToString1[A]: ToString1[A] = macro Magnolia.gen[A]

    @proxy(ToString2)
    implicit def deriveToString2[A]: ToString2[A] = macro Magnolia.gen[A]
  }

  object semiauto {
    @proxy(ToString1)
    def deriveToString1[A]: ToString1[A] = macro Magnolia.gen[A]

    @proxy(ToString2)
    def deriveToString2[A]: ToString2[A] = macro Magnolia.gen[A]
  }

```
