### PR TITLE
Added isObject to SealedTrait.Subtype

### DIFF
--- a/src/core/interface.scala
+++ b/src/core/interface.scala
@@ -84,6 +84,7 @@ object SealedTrait:
                (val typeInfo: TypeInfo,
                 val annotations: IArray[Any],
                 val typeAnnotations: IArray[Any],
+                val isObject: Boolean,
                 index: Int,
                 callByNeed: CallByNeed[Typeclass[SType]],
                 isType: Type => Boolean,

--- a/src/core/magnolia.scala
+++ b/src/core/magnolia.scala
@@ -73,7 +73,7 @@ trait Derivation[TypeClass[_]] extends CommonDerivation[TypeClass]:
       case _: EmptyTuple =>
         Nil
       case _: (s *: tail) =>
-        new SealedTrait.Subtype(typeInfo[s], IArray[Any](), IArray.from(paramTypeAnns[T]), idx,
+        new SealedTrait.Subtype(typeInfo[s], IArray[Any](), IArray.from(paramTypeAnns[T]), isObject[s], idx,
             CallByNeed(summonInline[Typeclass[s]]), x => m.ordinal(x) == idx,
             _.asInstanceOf[s & T]) :: subtypes[T, tail](m, idx + 1)
 

--- a/src/examples/objects.scala
+++ b/src/examples/objects.scala
@@ -1,0 +1,20 @@
+package magnolia.examples
+
+import magnolia._
+
+trait ObjectInfo[T] {
+  def subtypeIsObject: Seq[Boolean]
+}
+
+object ObjectInfo extends Derivation[ObjectInfo]:
+  def join[T](ctx: CaseClass[ObjectInfo, T]): ObjectInfo[T] =
+    new ObjectInfo[T]:
+      def subtypeIsObject: Seq[Boolean] = Nil
+
+  override def split[T](ctx: SealedTrait[ObjectInfo, T]): ObjectInfo[T] =
+    new ObjectInfo[T]:
+      def subtypeIsObject: Seq[Boolean] = ctx.subtypes.map(_.isObject)
+
+  given fallback[T]: ObjectInfo[T] =
+    new ObjectInfo[T]:
+      def subtypeIsObject: Seq[Boolean] = Nil

--- a/src/test/tests.scala
+++ b/src/test/tests.scala
@@ -45,6 +45,10 @@ case object Blue extends Color
 case object Orange extends Color
 case object Pink extends Color
 
+sealed trait Sport
+case object Boxing extends Sport
+case class Soccer(players: Int) extends Sport
+
 case class MyAnnotation(order: Int) extends StaticAnnotation
 case class MyTypeAnnotation(order: Int) extends StaticAnnotation
 
@@ -403,6 +407,16 @@ class Tests extends munit.FunSuite {
     test("sealed trait subtypes should be ordered") {
       val res = TypeNameInfo.derived[Color].subtypeNames.map(_.short)
       assertEquals(res, Seq("Red", "Green", "Blue", "Orange", "Pink"))
+    }
+
+    test("sealed trait subtypes should detect isObject") {
+      val subtypeIsObjects = ObjectInfo.derived[Sport].subtypeIsObject
+      assertEquals(subtypeIsObjects, Seq(true, false))
+    }
+
+    test("sealed trait enumeration should detect isObject") {
+      val subtypeIsObjects = ObjectInfo.derived[Color].subtypeIsObject
+      assertEquals(subtypeIsObjects, Seq(true, true, true, true, true))
     }
 
     test("case class typeName should be complete and unchanged") {


### PR DESCRIPTION
Fixes #164

This adds `isObject` as a parameter to `Subtype`.

One thing I was not sure on, is why the fallback implicit is required in traits used for testing (I see TypeNameInfo has it). This is only required for sealed traits which have a mixture of case classes and case objects.
